### PR TITLE
Completed tests for formatTime

### DIFF
--- a/client/formatTime.js
+++ b/client/formatTime.js
@@ -1,19 +1,21 @@
 function formatTime(seconds) {
   let str = '';
 
-  const hours = Math.floor(seconds / 3600);
+  const roundedSeconds = Math.round(seconds);
+
+  const hours = Math.floor(roundedSeconds / 3600);
   if (hours) {
     str = `${hours.toString()}:`;
   }
 
-  const minutes = Math.floor((seconds - hours * 3600) / 60);
+  const minutes = Math.floor((roundedSeconds - hours * 3600) / 60);
   if (str !== '') {
     str = `${str}${minutes.toString().padStart(2, '0')}:`;
   } else {
     str = `${minutes.toString()}:`;
   }
 
-  const remainingSeconds = Math.floor(seconds - 3600 * hours - 60 * minutes);
+  const remainingSeconds = Math.floor(roundedSeconds - 3600 * hours - 60 * minutes);
   str = `${str}${remainingSeconds.toString().padStart(2, '0')}`;
 
   return str;

--- a/tests/Model.test.js
+++ b/tests/Model.test.js
@@ -1,10 +1,10 @@
-const Model = require('./Model');
+const Model = require('../server/Model');
 const db = require('../db');
 
 beforeAll(() => db.connect());
 
 test('Test: Model.getChatsForVid(1)', () => Model.getChatsForVid(1).then(data => {
-  expect(data.length).toBe(12);
+  expect(data.length).toBe(10);
 }));
 
 afterAll(() => db.disconnect());

--- a/tests/formatTime.test.js
+++ b/tests/formatTime.test.js
@@ -1,0 +1,18 @@
+const formatTime = require('../client/formatTime');
+
+test('formatTime', () => expect(formatTime(0)).toBe('0:00'));
+test('formatTime', () => expect(formatTime(1)).toBe('0:01'));
+test('formatTime', () => expect(formatTime(60)).toBe('1:00'));
+test('formatTime', () => expect(formatTime(61)).toBe('1:01'));
+test('formatTime', () => expect(formatTime(599)).toBe('9:59'));
+test('formatTime', () => expect(formatTime(600)).toBe('10:00'));
+test('formatTime', () => expect(formatTime(3599)).toBe('59:59'));
+test('formatTime', () => expect(formatTime(3600)).toBe('1:00:00'));
+test('formatTime', () => expect(formatTime(3601)).toBe('1:00:01'));
+test('formatTime', () => expect(formatTime(8542)).toBe('2:22:22'));
+test('formatTime', () => expect(formatTime(120813)).toBe('33:33:33'));
+
+test('formatTime', () => expect(formatTime(0.4)).toBe('0:00'));
+test('formatTime', () => expect(formatTime(0.6)).toBe('0:01'));
+test('formatTime', () => expect(formatTime(59.6)).toBe('1:00'));
+test('formatTime', () => expect(formatTime(60.1)).toBe('1:00'));


### PR DESCRIPTION
Yay, testing works! When writing tests I noticed I wasn't handling partial seconds (i.e. I wasn't rounding fractions to the nearest second.) Minor impact on the UI, but now it's more correct.